### PR TITLE
Fix missing color icon

### DIFF
--- a/panels/color/cinnamon-color-panel.desktop.in.in
+++ b/panels/color/cinnamon-color-panel.desktop.in.in
@@ -2,7 +2,7 @@
 _Name=Color
 _Comment=Color management settings
 Exec=cinnamon-settings color
-Icon=preferences-color
+Icon=cinnamon-preferences-color
 Terminal=false
 Type=Application
 StartupNotify=true


### PR DESCRIPTION
closes

https://github.com/linuxmint/cinnamon-control-center/issues/12
