### PR TITLE
Fix missing bluetooth icon

### DIFF
--- a/panels/bluetooth/cinnamon-bluetooth-properties.desktop.in.in
+++ b/panels/bluetooth/cinnamon-bluetooth-properties.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 _Name=Bluetooth
 _Comment=Configure Bluetooth settings
-Icon=cinnamon-bluetooth
+Icon=bluetooth
 Exec=cinnamon-settings bluetooth
 Terminal=false
 Type=Application


### PR DESCRIPTION
cinnamon-bluetooth icon doesn't exist and shouldn't as provided by the system icon theme.
