### PR TITLE
Remove trailing whitespace to make autoreconf work

### DIFF
--- a/panels/sound/Makefile.am
+++ b/panels/sound/Makefile.am
@@ -13,7 +13,7 @@ AM_CPPFLAGS =					\
 	$(SOUND_PANEL_CFLAGS)			\
 	-DLOCALE_DIR=\""$(datadir)/locale"\"	\
 	-DLIBEXECDIR=\"$(libexecdir)\"		\
-	-DGLADEDIR=\""$(pkgdatadir)"\"		\     
+	-DGLADEDIR=\""$(pkgdatadir)"\"		\
 	-DICON_DATA_DIR="\"$(pkgdatadir)/icons\"" \
 	$(NULL)
 


### PR DESCRIPTION
Patch for those not using package management for building
