### PR TITLE
[2.4] Added two more time spans to power.ui

### DIFF
--- a/panels/power/power.ui
+++ b/panels/power/power.ui
@@ -40,8 +40,16 @@
         <col id="1">600</col>
       </row>
       <row>
+        <col id="0" translatable="yes">15 minutes</col>
+        <col id="1">900</col>
+      </row>
+      <row>
         <col id="0" translatable="yes">30 minutes</col>
         <col id="1">1800</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">45 minutes</col>
+        <col id="1">2700</col>
       </row>
       <row>
         <col id="0" translatable="yes">1 hour</col>
@@ -161,8 +169,16 @@
         <col id="1">600</col>
       </row>
       <row>
+        <col id="0" translatable="yes">15 minutes</col>
+        <col id="1">900</col>
+      </row>
+      <row>
         <col id="0" translatable="yes">30 minutes</col>
         <col id="1">1800</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">45 minutes</col>
+        <col id="1">2700</col>
       </row>
       <row>
         <col id="0" translatable="yes">1 hour</col>
@@ -191,8 +207,16 @@
         <col id="1">600</col>
       </row>
       <row>
+        <col id="0" translatable="yes">15 minutes</col>
+        <col id="1">900</col>
+      </row>
+      <row>
         <col id="0" translatable="yes">30 minutes</col>
         <col id="1">1800</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">45 minutes</col>
+        <col id="1">2700</col>
       </row>
       <row>
         <col id="0" translatable="yes">1 hour</col>


### PR DESCRIPTION
I felt the personal need for 15 minutes and 45 minutes time spans in the power module, so I added it. (E.g. I want my screen switched off after 15 minutes)
Actually I'd prefer a GtkSpinButton, which leaves the user more choice, but I'm fairly new to GTK and I didn't understand how the SpinButton exactly works. So I left it with the additional time spans.

Modifications tested on Linux Mint 17 Cinnamon Edition RC
