### PR TITLE
Set translation domain when loading datetime.ui and add generated translation files to deb package

### DIFF
--- a/debian/cinnamon-control-center-data.install
+++ b/debian/cinnamon-control-center-data.install
@@ -4,4 +4,5 @@ usr/share/desktop-directories
 usr/share/icons
 usr/share/polkit-1
 debian/source_cinnamon-control-center.py /usr/share/apport/package-hooks
+usr/share/locale/* /usr/share/cinnamon/locale
 

--- a/panels/datetime/cc-datetime-panel.c
+++ b/panels/datetime/cc-datetime-panel.c
@@ -905,6 +905,7 @@ cc_date_time_panel_init (CcDateTimePanel *self)
 
   priv->builder = gtk_builder_new ();
 
+  gtk_builder_set_translation_domain (priv->builder, GETTEXT_PACKAGE);
   ret = gtk_builder_add_objects_from_file (priv->builder, DATADIR"/datetime.ui",
                                            objects, &err);
 


### PR DESCRIPTION
When loading ui file with GtkBuilder, it's necessary to use gtk_builder_set_translation_domain.
Also, add generated cinnamon-control-center-timezones.mo to the deb package, otherwise the datetime module's timezone in cinnamon-settings won't have translations
