### PR TITLE
color: Do not set the 'View Details' button for virtual profiles.

### DIFF
--- a/panels/color/cc-color-panel.c
+++ b/panels/color/cc-color-panel.c
@@ -1136,11 +1136,9 @@ gcm_prefs_profile_clicked (CcColorPanel *prefs, CdProfile *profile, CdDevice *de
   /* allow getting profile info */
   widget = GTK_WIDGET (gtk_builder_get_object (priv->builder,
                "toolbutton_profile_view"));
-  if (cd_profile_get_filename (profile) != NULL &&
-      (s = g_find_program_in_path ("gcm-viewer")) != NULL)
+  if (cd_profile_get_filename (profile) != NULL)
     {
       gtk_widget_set_sensitive (widget, TRUE);
-      g_free (s);
     }
   else
   gtk_widget_set_sensitive (widget, FALSE);

--- a/panels/color/cc-color-panel.c
+++ b/panels/color/cc-color-panel.c
@@ -1136,7 +1136,14 @@ gcm_prefs_profile_clicked (CcColorPanel *prefs, CdProfile *profile, CdDevice *de
   /* allow getting profile info */
   widget = GTK_WIDGET (gtk_builder_get_object (priv->builder,
                "toolbutton_profile_view"));
-  gtk_widget_set_sensitive (widget, TRUE);
+  if (cd_profile_get_filename (profile) != NULL &&
+      (s = g_find_program_in_path ("gcm-viewer")) != NULL)
+    {
+      gtk_widget_set_sensitive (widget, TRUE);
+      g_free (s);
+    }
+  else
+  gtk_widget_set_sensitive (widget, FALSE);
 
   /* hide device specific stuff */
   widget = GTK_WIDGET (gtk_builder_get_object (priv->builder,


### PR DESCRIPTION
Fixes

https://bugzilla.redhat.com/show_bug.cgi?id=1119408

```
Description of problem:
1. Open Cinnamon Control Center
2. Select 'Color'
3. Select a device (I picked my printer)
4. Select a color profile (I picked Default RGB)
5. Click 'View details'

crash occurred at this point.
```

based on

https://git.gnome.org/browse/gnome-control-center/commit/panels/color/cc-color-panel.c?h=gnome-3-14&id=e9b0527b4b346e2c4ff2ae00bbf0c415186a5a85