### PR TITLE
Remove the NetworkManager version checking altogether

### DIFF
--- a/panels/network/cc-network-panel.c
+++ b/panels/network/cc-network-panel.c
@@ -1311,30 +1311,17 @@ static gboolean
 panel_check_network_manager_version (CcNetworkPanel *panel)
 {
         const gchar *version;
-        gchar **split = NULL;
-        guint major = 0;
-        guint micro = 0;
-        guint minor = 0;
         gboolean ret = TRUE;
 
         /* parse running version */
         version = nm_client_get_version (panel->priv->client);
-        if (version != NULL) {
-                split = g_strsplit (version, ".", -1);
-                major = atoi (split[0]);
-                minor = atoi (split[1]);
-                micro = atoi (split[2]);
-        }
-
-        /* is it too new or old */
-        if (major > 0 || minor > 9 || (minor <= 8 && micro < 992)) {
+        if (version == NULL) {
                 ret = FALSE;
 
                 /* do modal dialog in idle so we don't block startup */
                 panel->priv->nm_warning_idle = g_idle_add ((GSourceFunc)display_version_warning_idle, panel);
         }
 
-        g_strfreev (split);
         return ret;
 }
 
@@ -1381,8 +1368,8 @@ on_toplevel_map (GtkWidget      *widget,
 {
         gboolean ret;
 
-        /* is the user compiling against a new version, but running an
-         * old daemon version? */
+        /* is the user compiling against a new version, but not running
+         * the daemon? */
         ret = panel_check_network_manager_version (panel);
         if (ret) {
                 manager_running (panel->priv->client, NULL, panel);


### PR DESCRIPTION
Taken from upstream commit

https://git.gnome.org/browse/gnome-control-center/patch/panels/network/cc-network-panel.c?id=f30e6df1d4665b06a45ad7bbe7a2ed2bfa9387f5