### PR TITLE
network: Allocate storage for zone name during D-Bus call

### DIFF
--- a/panels/network/connection-editor/firewall-helpers.c
+++ b/panels/network/connection-editor/firewall-helpers.c
@@ -72,6 +72,7 @@ get_zones_reply (GObject      *source,
         }
         gtk_combo_box_set_active (GTK_COMBO_BOX (d->combo), idx);
 
+        g_free (d->zone);
         g_free (d);
 }
 
@@ -86,7 +87,7 @@ firewall_ui_setup (NMSettingConnection *setting,
         bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, NULL);
 
         d = g_new0 (GetZonesReplyData, 1);
-        d->zone = nm_setting_connection_get_zone (setting);
+        d->zone = g_strdup (nm_setting_connection_get_zone (setting));
         d->combo = combo;
 
         g_dbus_connection_call (bus,


### PR DESCRIPTION
The call to nm_setting_connection_get_zone() returns a pointer to
memory that will be freed before the D-Bus reply handler is called.
Make sure to take a copy of the string, and free it when finished.

https://bugzilla.gnome.org/show_bug.cgi?id=739971

https://git.gnome.org/browse/gnome-control-center/patch/panels/network/connection-editor?id=dba40e13019c9adef1137a13e3a065c7a048ea46