### PR TITLE
Optional NetworkManager, ModemManager, Colord

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,6 @@ PKG_CHECK_MODULES(DISPLAY_PANEL, $COMMON_MODULES cinnamon-desktop x11)
 PKG_CHECK_MODULES(MEDIA_PANEL, $COMMON_MODULES)
 
 PKG_CHECK_MODULES(NETWORK_PANEL, $COMMON_MODULES gmodule-2.0)
-PKG_CHECK_MODULES(COLOR_PANEL, $COMMON_MODULES colord >= 0.1.14)
 PKG_CHECK_MODULES(REGION_PANEL, $COMMON_MODULES libgnomekbd >= 2.91.91
                   polkit-gobject-1 >= $POLKIT_REQUIRED_VERSION
                   libxklavier >= 5.1 libgnomekbdui >= 2.91.91)
@@ -195,15 +194,51 @@ if test x"$enable_cups" != x"no" ; then
   AC_SUBST(CUPS_LIBS)
 fi
 
+build_color=false
+AC_ARG_ENABLE(color,
+       AC_HELP_STRING([--disable-color],
+               [disable color management panel]),
+       [case "${enableval}" in
+               yes) WANT_COLOR=yes ;;
+               no) WANT_COLOR=no ;;
+               *) AC_MSG_ERROR(bad value ${enableval} for --disable-color) ;;
+       esac],
+       [WANT_COLOR=yes]) dnl Default value
+
+if test x$WANT_COLOR = xyes; then
+       PKG_CHECK_MODULES(COLOR_PANEL, $COMMON_MODULES colord >= 0.1.14)
+       build_color=true
+fi
+if test "x$build_color" = xtrue ; then
+       AC_DEFINE(BUILD_COLOR, 1, [Define to 1 to build the Color panel])
+fi
+AM_CONDITIONAL(BUILD_COLOR, test "x$build_color" = "xtrue")
+AC_SUBST(COLOR_PANEL_CFLAGS)
+AC_SUBST(COLOR_PANEL_LIBS)
+
 build_wacom=false
-PKG_CHECK_MODULES(WACOM_PANEL, [$COMMON_MODULES
+AC_ARG_ENABLE(wacom,
+       AC_HELP_STRING([--disable-wacom],
+               [disable wacom management panel]),
+       [case "${enableval}" in
+               yes) WANT_WACOM=yes ;;
+               no) WANT_WACOM=no ;;
+               *) AC_MSG_ERROR(bad value ${enableval} for --disable-wacom) ;;
+       esac],
+       [WANT_WACOM=yes]) dnl Default value
+
+if test x$WANT_WACOM = xyes; then
+        PKG_CHECK_MODULES(WACOM_PANEL, [$COMMON_MODULES
                   cinnamon-settings-daemon >= $CSD_REQUIRED_VERSION
                   xi >= 1.2 x11 libwacom >= $LIBWACOM_REQUIRED_VERSION
                   cinnamon-desktop
-                  gtk+-3.0 >= 3.8.0],
-                  [build_wacom="true" AC_DEFINE(HAVE_WACOM, 1, [Define if wacom is being build])], [build_wacom="false"])
-
+                  gtk+-3.0 >= 3.8.0])
+        build_wacom="true"
+        AC_DEFINE(HAVE_WACOM, 1, [Define if wacom is being build])]
+fi
 AM_CONDITIONAL(BUILD_WACOM, test "x$build_wacom" = "xtrue")
+AC_SUBST(WACOM_PANEL_CFLAGS)
+AC_SUBST(WACOM_PANEL_LIBS)
 
 # This is a hard-dependency for the region and user-accounts panels
 PKG_CHECK_MODULES(ISOCODES, iso-codes)
@@ -351,6 +386,13 @@ fi
 #else
 #	AC_MSG_NOTICE([   Using ConsoleKit for session tracking])
 #fi
+
+if test "x$build_color" = "xtrue"; then
+	AC_MSG_NOTICE([** Colord support (Color management panel)])
+else
+	AC_MSG_NOTICE([   Colord support disabled])
+fi
+
 if test "x$build_wacom" = "xtrue"; then
 	AC_MSG_NOTICE([** Wacom support (Wacom panel)])
 else

--- a/configure.ac
+++ b/configure.ac
@@ -131,26 +131,68 @@ PKG_CHECK_MODULES(REGION_PANEL, $COMMON_MODULES libgnomekbd >= 2.91.91
 #----------------------------------------------
 # Network Manager Stuff
 
-PKG_CHECK_MODULES(NETWORK_MANAGER, NetworkManager >= $NETWORK_MANAGER_REQUIRED_VERSION
-                  libnm-glib >= $NETWORK_MANAGER_REQUIRED_VERSION
-                  libnm-glib-vpn >= $NETWORK_MANAGER_REQUIRED_VERSION
-                  libnm-util >= $NETWORK_MANAGER_REQUIRED_VERSION
-                  libnm-gtk >= $NETWORK_MANAGER_APPLET_REQUIRED_VERSION
-                  mm-glib >= $MODEM_MANAGER_REQUIRED_VERSION,
-                  [have_networkmanager=yes], have_networkmanager=no)
-if test "x$have_networkmanager" = xno ; then
-        AC_MSG_WARN(*** Network panel will not be built (NetworkManager or ModemManager not found) ***)
-else
-	AC_DEFINE(BUILD_NETWORK, 1, [Define to 1 to build the Network panel])
+AC_ARG_ENABLE(networkmanager,
+              AC_HELP_STRING([--disable-networkmanager],
+                             [build NetworkManager support]),
+              [case "${enableval}" in
+                      yes) enable_networkmanager=yes ;;
+                      no) enable_networkmanager=no ;;
+                      *) AC_MSG_ERROR(bad value ${enableval} for --disable-networkmanager) ;;
+              esac],
+              [enable_networkmanager=yes]) dnl Enabled by default
+
+if test "x$enable_networkmanager" = xyes; then
+    PKG_CHECK_MODULES(NETWORK_MANAGER, NetworkManager >= $NETWORK_MANAGER_REQUIRED_VERSION
+                      libnm-glib >= $NETWORK_MANAGER_REQUIRED_VERSION
+                      libnm-glib-vpn >= $NETWORK_MANAGER_REQUIRED_VERSION
+                      libnm-util >= $NETWORK_MANAGER_REQUIRED_VERSION
+                      libnm-gtk >= $NETWORK_MANAGER_APPLET_REQUIRED_VERSION,
+                      [have_networkmanager=yes], have_networkmanager=no)
+    if test "x$have_networkmanager" = xno ; then
+        AC_MSG_ERROR(*** NetworkManager not found ***)
+    fi
+
+    AC_DEFINE(BUILD_NETWORK, 1, [Define to 1 to build the Network panel])
+
+    if test x${have_networkmanager} = xyes; then
+      AC_DEFINE(HAVE_NETWORK_MANAGER, 1, [Define to 1 if NetworkManager is available])
+      NM_VPN_CONFIG_DIR=`$PKG_CONFIG --variable configdir NetworkManager`/VPN
+      NM_VPN_MODULE_DIR=`$PKG_CONFIG --variable plugindir NetworkManager`
+      AC_SUBST(NM_VPN_CONFIG_DIR)
+      AC_SUBST(NM_VPN_MODULE_DIR)
+    fi
 fi
+
 AM_CONDITIONAL(BUILD_NETWORK, [test x$have_networkmanager = xyes])
-if test x${have_networkmanager} = xyes; then
-  AC_DEFINE(HAVE_NETWORK_MANAGER, 1, [Define to 1 if NetworkManager is available])
-  NM_VPN_CONFIG_DIR=`$PKG_CONFIG --variable configdir NetworkManager`/VPN
-  NM_VPN_MODULE_DIR=`$PKG_CONFIG --variable plugindir NetworkManager`
-  AC_SUBST(NM_VPN_CONFIG_DIR)
-  AC_SUBST(NM_VPN_MODULE_DIR)
+
+AC_ARG_ENABLE(modemmanager,
+              AC_HELP_STRING([--disable-modemmanager],
+                             [build ModemManager support]),
+              [case "${enableval}" in
+                      yes) enable_modemmanager=yes ;;
+                      no) enable_modemmanager=no ;;
+                      *) AC_MSG_ERROR(bad value ${enableval} for --disable-modemmanager) ;;
+              esac],
+              [enable_modemmanager=yes]) dnl Enable by default
+
+if test "x$enable_modemmanager" = xyes; then
+    if test "x$enable_networkmanager" = xno; then
+        AC_MSG_ERROR(*** NetworkManager is required by ModemManager ***)
+    fi
 fi
+
+if test "x$enable_modemmanager" = xyes; then
+    PKG_CHECK_MODULES(MODEM_MANAGER, mm-glib >= $MODEM_MANAGER_REQUIRED_VERSION,
+                      [have_modemmanager=yes], have_modemmanager=no)
+
+    if test "x$have_modemmanager" = xno ; then
+        AC_MSG_ERROR(*** ModemManager not found ***)
+    fi
+
+    AC_DEFINE(BUILD_MODEM, 1, [Define 1 to build ModemManager support])
+fi
+
+AM_CONDITIONAL(BUILD_MODEM, [test x$have_modemmanager = xyes])
 
 # Work-around for https://bugzilla.gnome.org/show_bug.cgi?id=723769
 PKG_CHECK_MODULES(NM_UNSTABLE_CHECK, libnm-util >= 0.9.9.0, nm_unstable=yes, nm_unstable=no)
@@ -380,6 +422,11 @@ if test "x$have_networkmanager" = "xyes"; then
 	AC_MSG_NOTICE([** NetworkManager (Network panel)])
 else
 	AC_MSG_NOTICE([   Network panel disabled])
+fi
+if test "x$have_modemmanager" = "xyes"; then
+	AC_MSG_NOTICE([** ModemManager support enabled])
+else
+	AC_MSG_NOTICE([   ModemManager support disabled])
 fi
 #if test "x$with_systemd" = "xyes"; then
 #	AC_MSG_NOTICE([** systemd (Systemd session tracking)])

--- a/panels/Makefile.am
+++ b/panels/Makefile.am
@@ -2,7 +2,6 @@ NULL =
 
 enabled_panels = \
 	common \
-	color \
 	display \
 	region \
 	datetime
@@ -13,6 +12,12 @@ if BUILD_NETWORK
 enabled_panels += network
 else
 disabled_panels += network
+endif
+
+if BUILD_COLOR
+enabled_panels += color
+else
+disabled_panels += color
 endif
 
 if BUILD_WACOM

--- a/panels/network/Makefile.am
+++ b/panels/network/Makefile.am
@@ -32,8 +32,6 @@ libnetwork_la_SOURCES =					\
 	net-device-simple.h				\
 	net-device-ethernet.c				\
 	net-device-ethernet.h				\
-	net-device-mobile.c				\
-	net-device-mobile.h				\
 	net-device-bond.c				\
 	net-device-bond.h				\
 	net-device-bridge.c				\
@@ -50,6 +48,14 @@ libnetwork_la_SOURCES =					\
 	list-box-helper.c			\
 	cc-network-panel.c				\
 	cc-network-panel.h
+
+if BUILD_MODEM
+libnetwork_la_SOURCES +=			\
+	net-device-mobile.c				\
+	net-device-mobile.h
+NETWORK_PANEL_CFLAGS += -DBUILD_MODEM
+AM_CPPFLAGS += $(MODEM_MANAGER_CFLAGS)
+endif
 
 TEAM_FILES = net-device-team.c net-device-team.h
 EXTRA_DIST = $(TEAM_FILES)

--- a/panels/network/cc-network-panel.c
+++ b/panels/network/cc-network-panel.c
@@ -48,7 +48,9 @@
 #include "network-dialogs.h"
 #include "connection-editor/net-connection-editor.h"
 
+#ifdef BUILD_MODEM
 #include <libmm-glib.h>
+#endif
 
 CC_PANEL_REGISTER (CcNetworkPanel, cc_network_panel)
 
@@ -70,7 +72,11 @@ struct _CcNetworkPanelPrivate
         GtkBuilder       *builder;
         GtkWidget        *treeview;
         NMClient         *client;
+#ifdef BUILD_MODEM
         MMManager        *modem_manager;
+#else
+        void             *modem_manager;
+#endif
         NMRemoteSettings *remote_settings;
         gboolean          updating_device;
         guint             nm_warning_idle;
@@ -1435,7 +1441,7 @@ cc_network_panel_init (CcNetworkPanel *panel)
                           G_CALLBACK (device_added_cb), panel);
         g_signal_connect (panel->priv->client, "device-removed",
                           G_CALLBACK (device_removed_cb), panel);
-
+#ifdef BUILD_MODEM
         /* Setup ModemManager client */
         system_bus = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
         if (system_bus == NULL) {
@@ -1454,7 +1460,9 @@ cc_network_panel_init (CcNetworkPanel *panel)
                 }
                 g_object_unref (system_bus);
         }
-
+#else
+        panel->priv->modem_manager = NULL;
+#endif
         widget = GTK_WIDGET (gtk_builder_get_object (panel->priv->builder,
                                                      "add_toolbutton"));
         g_signal_connect (widget, "clicked",


### PR DESCRIPTION
Hi from the Gentoo user!

I've created a set of patches to be able to disable ModemManager while keeping NetworkManager and network panel working and also Colord (patch from Gentoo) during configure / building stages.

Would be great if you could merge and adopt changes for the next release as it gives better control over build deps.

Thanks in advance!
