### PR TITLE
network: Don't try to get secrets for new connections

### DIFF
--- a/panels/network/connection-editor/net-connection-editor.c
+++ b/panels/network/connection-editor/net-connection-editor.c
@@ -553,7 +553,7 @@ net_connection_editor_set_connection (NetConnectionEditor *editor,
                 const gchar *security_setting;
 
                 security_setting = ce_page_get_security_setting (page);
-                if (!security_setting) {
+                if (!security_setting || editor->is_new_connection) {
                         ce_page_complete_init (page, NULL, NULL, NULL);
                 } else {
                         get_secrets_for_page (editor, page, security_setting);


### PR DESCRIPTION
Based on https://git.gnome.org/browse/gnome-control-center/commit/panels/network?id=2e6149b4b83cd6ce47ad079a6df717e88a67998a

From 2e6149b4b83cd6ce47ad079a6df717e88a67998a Mon Sep 17 00:00:00 2001
From: Rui Matos tiagomatos@gmail.com
Date: Tue, 26 Jan 2016 18:35:52 +0100
Subject: network: Don't try to get secrets for new connections

We don't need secrets for new connections and, in fact, trying to
retrieve secrets in that case will fail because we have a plain
NMConnection instead of a NMRemoteConnection.

The above mentioned error would result in the page never being
initialized.
