### PR TITLE
network: Return better error when 8021x security is invalid

### DIFF
--- a/panels/network/connection-editor/ce-page-8021x-security.c
+++ b/panels/network/connection-editor/ce-page-8021x-security.c
@@ -131,7 +131,7 @@ validate (CEPage *cepage, NMConnection *connection, GError **error)
 		NMSetting *s_8021x;
 
 		/* FIXME: get failed property and error out of wireless security objects */
-		valid = wireless_security_validate (page->security, NULL);
+		valid = wireless_security_validate (page->security, error);
 		if (valid) {
 			NMSetting *s_con;
 
@@ -151,8 +151,7 @@ validate (CEPage *cepage, NMConnection *connection, GError **error)
 			nm_connection_add_setting (connection, NM_SETTING (g_object_ref (s_8021x)));
 
 			g_object_unref (tmp_connection);
-		} else
-			g_set_error (error, NM_CONNECTION_ERROR, NM_CONNECTION_ERROR_UNKNOWN, "Invalid 802.1x security");
+		}
 	} else {
 		nm_connection_remove_setting (connection, NM_TYPE_SETTING_802_1X);
 		valid = TRUE;


### PR DESCRIPTION
Based on https://git.gnome.org/browse/gnome-control-center/commit/panels/network/connection-editor?id=b0329f8ef6c025c9c20453132297c9772cb29efc

From b0329f8ef6c025c9c20453132297c9772cb29efc Mon Sep 17 00:00:00 2001
From: Bastien Nocera hadess@hadess.net
Date: Tue, 14 Jun 2016 14:11:25 +0200
Subject: network: Return better error when 8021x security is invalid

Rather than the generic "Invalid 802.1x security".

https://bugzilla.gnome.org/show_bug.cgi?id=769230
