### PR TITLE
Fix build

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -24,7 +24,6 @@ fi
 
 aclocal --install || exit 1
 glib-gettextize --force --copy || exit 1
-gtkdocize --copy || exit 1
 intltoolize --force --copy --automake || exit 1
 autoreconf --verbose --force --install || exit 1
 


### PR DESCRIPTION
```
You will also need config.guess and config.sub, which you can get from
ftp://ftp.gnu.org/pub/gnu/config/.

gtkdocize: GTK_DOC_CHECK not called in ./configure.ac
```