### PR TITLE
all: Simplify and fix i18n

### DIFF
--- a/panels/color/cc-color-panel.c
+++ b/panels/color/cc-color-panel.c
@@ -25,7 +25,7 @@
 #include <gtk/gtk.h>
 #include <gdk/gdkx.h>
 #include <gio/gio.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include "cc-color-panel.h"
 
 #define WID(b, w) (GtkWidget *) gtk_builder_get_object (b, w)
@@ -2484,8 +2484,6 @@ cc_color_panel_init (CcColorPanel *prefs)
   priv = prefs->priv = COLOR_PANEL_PRIVATE (prefs);
 
   priv->builder = gtk_builder_new ();
-  gtk_builder_set_translation_domain (priv->builder, GETTEXT_PACKAGE);
-
   gtk_builder_add_from_file (priv->builder,
                              CINNAMONCC_UI_DIR "/color.ui",
                              &error);
@@ -2676,6 +2674,7 @@ cc_color_panel_init (CcColorPanel *prefs)
 void
 cc_color_panel_register (GIOModule *module)
 {
+  textdomain (GETTEXT_PACKAGE);
   bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
   cc_color_panel_register_type (G_TYPE_MODULE (module));

--- a/panels/color/color-module.c
+++ b/panels/color/color-module.c
@@ -24,7 +24,7 @@
 
 #include "cc-color-panel.h"
 
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 void
 g_io_module_load (GIOModule *module)

--- a/panels/common/cc-common-language.c
+++ b/panels/common/cc-common-language.c
@@ -25,7 +25,7 @@
 #include <locale.h>
 
 #include <glib.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
 #include <fontconfig/fontconfig.h>

--- a/panels/common/cc-language-chooser.c
+++ b/panels/common/cc-language-chooser.c
@@ -25,7 +25,7 @@
 #include <locale.h>
 
 #include <glib.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <gio/gio.h>
 #include <gtk/gtk.h>
 
@@ -287,7 +287,6 @@ cc_language_chooser_new (GtkWidget *parent, gboolean regions)
 	GtkTreeModel *filter_model;
 
         builder = gtk_builder_new ();
-        gtk_builder_set_translation_domain (builder, GETTEXT_PACKAGE);
         filename = UIDIR "/language-chooser.ui";
         if (!g_file_test (filename, G_FILE_TEST_EXISTS))
                 filename = "data/language-chooser.ui";

--- a/panels/common/gdm-languages.c
+++ b/panels/common/gdm-languages.c
@@ -34,7 +34,7 @@
 #include <sys/stat.h>
 
 #include <glib.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <glib/gstdio.h>
 
 #include "gdm-languages.h"

--- a/panels/common/list-languages.c
+++ b/panels/common/list-languages.c
@@ -1,7 +1,7 @@
 #include "config.h"
 
 #include <glib.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <locale.h>
 #include <glib-object.h>
 #include "gdm-languages.h"
@@ -12,6 +12,8 @@ int main (int argc, char **argv)
 	guint i;
 
 	setlocale (LC_ALL, NULL);
+	textdomain (GETTEXT_PACKAGE);
+	bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 
 	g_type_init ();

--- a/panels/datetime/cc-datetime-panel.c
+++ b/panels/datetime/cc-datetime-panel.c
@@ -903,8 +903,6 @@ cc_date_time_panel_init (CcDateTimePanel *self)
   }
 
   priv->builder = gtk_builder_new ();
-
-  gtk_builder_set_translation_domain (priv->builder, GETTEXT_PACKAGE);
   ret = gtk_builder_add_objects_from_file (priv->builder, DATADIR"/datetime.ui",
                                            objects, &err);
 
@@ -1042,7 +1040,9 @@ cc_date_time_panel_init (CcDateTimePanel *self)
 void
 cc_date_time_panel_register (GIOModule *module)
 {
-  bind_textdomain_codeset (GETTEXT_PACKAGE_TIMEZONES, "UTF-8");
+  textdomain (GETTEXT_PACKAGE);
+  bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+  bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 
   cc_date_time_panel_register_type (G_TYPE_MODULE (module));
   g_io_extension_point_implement (CC_SHELL_PANEL_EXTENSION_POINT,

--- a/panels/datetime/datetime-module.c
+++ b/panels/datetime/datetime-module.c
@@ -23,19 +23,11 @@
 
 #include "cc-datetime-panel.h"
 
-#include <glib/gi18n-lib.h>
-
-#define GETTEXT_PACKAGE_TIMEZONES GETTEXT_PACKAGE "-timezones"
+#include <glib/gi18n.h>
 
 void
 g_io_module_load (GIOModule *module)
 {
-  bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
-  bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
-
-  bindtextdomain (GETTEXT_PACKAGE_TIMEZONES, "/usr/share/locale");
-  bind_textdomain_codeset (GETTEXT_PACKAGE_TIMEZONES, "UTF-8");
-
   /* register the panel */
   cc_date_time_panel_register (module);
 }

--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -33,7 +33,7 @@
 #include <libcinnamon-desktop/gnome-rr-config.h>
 #include <gdk/gdkx.h>
 #include <X11/Xlib.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <libcinnamon-desktop/cdesktop-enums.h>
 
 #include "cc-rr-labeler.h"
@@ -2507,7 +2507,6 @@ cc_display_panel_constructor (GType                  gtype,
 
   error = NULL;
   self->priv->builder = builder = gtk_builder_new ();
-  gtk_builder_set_translation_domain (self->priv->builder, GETTEXT_PACKAGE);
   if (!gtk_builder_add_objects_from_file (builder, UIDIR "/display-capplet.ui", objects, &error))
     {
       g_warning ("Could not parse UI definition: %s", error->message);
@@ -2603,6 +2602,7 @@ cc_display_panel_constructor (GType                  gtype,
 void
 cc_display_panel_register (GIOModule *module)
 {
+  textdomain (GETTEXT_PACKAGE);
   bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
   cc_display_panel_register_type (G_TYPE_MODULE (module));

--- a/panels/display/cc-rr-labeler.c
+++ b/panels/display/cc-rr-labeler.c
@@ -26,7 +26,7 @@
  */
 
 #include <config.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
 #include <X11/Xproto.h>

--- a/panels/display/display-module.c
+++ b/panels/display/display-module.c
@@ -23,7 +23,7 @@
 
 #include "cc-display-panel.h"
 
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 void
 g_io_module_load (GIOModule *module)

--- a/panels/network/cc-network-panel.c
+++ b/panels/network/cc-network-panel.c
@@ -1390,6 +1390,7 @@ cc_network_panel_init (CcNetworkPanel *panel)
 void
 cc_network_panel_register (GIOModule *module)
 {
+        textdomain (GETTEXT_PACKAGE);
         bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
         bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
         cc_network_panel_register_type (G_TYPE_MODULE (module));

--- a/panels/network/network-module.c
+++ b/panels/network/network-module.c
@@ -18,7 +18,7 @@
 
 #include <config.h>
 #include "cc-network-panel.h"
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 void
 g_io_module_load (GIOModule *module)

--- a/panels/online-accounts/cc-online-accounts-panel.c
+++ b/panels/online-accounts/cc-online-accounts-panel.c
@@ -22,7 +22,7 @@
 
 #include <gio/gio.h>
 #include <string.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 #define GOA_API_IS_SUBJECT_TO_CHANGE
 #include <goa/goa.h>
@@ -968,6 +968,7 @@ on_remove_button_clicked (CcGoaPanel *panel)
 void
 cc_goa_panel_register (GIOModule *module)
 {
+        textdomain (GETTEXT_PACKAGE);
         bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
         bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
         cc_goa_panel_register_type (G_TYPE_MODULE (module));

--- a/panels/online-accounts/online-accounts-module.c
+++ b/panels/online-accounts/online-accounts-module.c
@@ -18,7 +18,7 @@
 
 #include <config.h>
 #include "cc-online-accounts-panel.h"
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 void
 g_io_module_load (GIOModule *module)

--- a/panels/region/cc-region-panel.c
+++ b/panels/region/cc-region-panel.c
@@ -21,7 +21,7 @@
 #include "config.h"
 #include "cc-region-panel.h"
 #include <gtk/gtk.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 #include "cinnamon-region-panel-xkb.h"
 
@@ -105,7 +105,6 @@ cc_region_panel_init (CcRegionPanel * self)
 	desktop = g_getenv ("XDG_CURRENT_DESKTOP");
 
 	priv->builder = gtk_builder_new ();
-    gtk_builder_set_translation_domain (priv->builder, GETTEXT_PACKAGE);
 	gtk_builder_add_from_file (priv->builder,
 				   CINNAMONCC_UI_DIR "/cinnamon-region-panel.ui",
 				   &error);
@@ -128,8 +127,9 @@ cc_region_panel_init (CcRegionPanel * self)
 void
 cc_region_panel_register (GIOModule * module)
 {
-    bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
-    bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+	textdomain (GETTEXT_PACKAGE);
+	bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	cc_region_panel_register_type (G_TYPE_MODULE (module));
 	g_io_extension_point_implement (CC_SHELL_PANEL_EXTENSION_POINT,
 					CC_TYPE_REGION_PANEL,

--- a/panels/region/cinnamon-region-panel-xkb.c
+++ b/panels/region/cinnamon-region-panel-xkb.c
@@ -25,7 +25,7 @@
 
 #include <string.h>
 #include <gdk/gdkx.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 #include "cinnamon-region-panel-xkb.h"
 

--- a/panels/region/cinnamon-region-panel-xkblt.c
+++ b/panels/region/cinnamon-region-panel-xkblt.c
@@ -24,7 +24,7 @@
 #endif
 
 #include <gdk/gdkx.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 #include <libgnomekbd/gkbd-desktop-config.h>
 #include <libgnomekbd/gkbd-keyboard-drawing.h>

--- a/panels/region/cinnamon-region-panel-xkbltadd.c
+++ b/panels/region/cinnamon-region-panel-xkbltadd.c
@@ -378,7 +378,6 @@ xkb_layout_choose (GtkBuilder * dialog)
 	GtkTreeSelection *selection;
 	GtkListStore *model;
 	GtkTreeModelFilter *filtered_model;
-    gtk_builder_set_translation_domain (chooser_dialog, GETTEXT_PACKAGE);
 	gtk_builder_add_from_file (chooser_dialog, CINNAMONCC_UI_DIR
 				   "/cinnamon-region-panel-layout-chooser.ui",
 				   NULL);

--- a/panels/region/cinnamon-region-panel-xkbot.c
+++ b/panels/region/cinnamon-region-panel-xkbot.c
@@ -24,7 +24,7 @@
 #  include <config.h>
 #endif
 
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <string.h>
 
 #include "cinnamon-region-panel-xkb.h"
@@ -442,7 +442,6 @@ xkb_options_popup_dialog (GtkBuilder * dialog)
 	GtkWidget *chooser;
 
 	chooser_dialog = gtk_builder_new ();
-    gtk_builder_set_translation_domain (chooser_dialog, GETTEXT_PACKAGE);
 	gtk_builder_add_from_file (chooser_dialog, CINNAMONCC_UI_DIR
 				   "/cinnamon-region-panel-options-dialog.ui",
 				   NULL);

--- a/panels/region/region-module.c
+++ b/panels/region/region-module.c
@@ -23,7 +23,7 @@
 
 #include "cc-region-panel.h"
 
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 void
 g_io_module_load (GIOModule * module)

--- a/panels/wacom/cc-wacom-page.c
+++ b/panels/wacom/cc-wacom-page.c
@@ -22,7 +22,7 @@
 
 #include <config.h>
 
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
 #include "cc-wacom-page.h"
@@ -865,7 +865,6 @@ map_buttons_button_clicked_cb (GtkButton   *button,
 
 	g_assert (priv->mapping_builder == NULL);
 	priv->mapping_builder = gtk_builder_new ();
-	gtk_builder_set_translation_domain (priv->mapping_builder, GETTEXT_PACKAGE);
 	gtk_builder_add_from_resource (priv->mapping_builder,
                                        "/org/cinnamon/control-center/wacom/button-mapping.ui",
                                        &error);
@@ -1125,7 +1124,6 @@ cc_wacom_page_init (CcWacomPage *self)
 	priv = self->priv = WACOM_PAGE_PRIVATE (self);
 
 	priv->builder = gtk_builder_new ();
-	gtk_builder_set_translation_domain (priv->builder, GETTEXT_PACKAGE);
 	gtk_builder_add_objects_from_resource (priv->builder,
                                                "/org/cinnamon/control-center/wacom/cinnamon-wacom-properties.ui",
                                                objects,

--- a/panels/wacom/cc-wacom-panel.c
+++ b/panels/wacom/cc-wacom-panel.c
@@ -24,7 +24,7 @@
 
 #include <string.h>
 #include <gtk/gtk.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 #include "cc-wacom-panel.h"
 #include "cc-wacom-page.h"
@@ -318,7 +318,6 @@ cc_wacom_panel_init (CcWacomPanel *self)
         g_resources_register (cc_wacom_get_resource ());
 
 	priv->builder = gtk_builder_new ();
-	gtk_builder_set_translation_domain (priv->builder, GETTEXT_PACKAGE);
 	gtk_builder_add_objects_from_resource (priv->builder,
                                                "/org/cinnamon/control-center/wacom/cinnamon-wacom-properties.ui",
                                                objects,
@@ -378,6 +377,7 @@ void
 cc_wacom_panel_register (GIOModule *module)
 {
 	cc_wacom_panel_register_type (G_TYPE_MODULE (module));
+	textdomain (GETTEXT_PACKAGE);
 	bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	g_io_extension_point_implement (CC_SHELL_PANEL_EXTENSION_POINT,

--- a/panels/wacom/cc-wacom-stylus-page.c
+++ b/panels/wacom/cc-wacom-stylus-page.c
@@ -300,7 +300,6 @@ cc_wacom_stylus_page_init (CcWacomStylusPage *self)
 	priv = self->priv = WACOM_STYLUS_PAGE_PRIVATE (self);
 
 	priv->builder = gtk_builder_new ();
-	gtk_builder_set_translation_domain (priv->builder, GETTEXT_PACKAGE);
 	gtk_builder_add_objects_from_resource (priv->builder,
                                                "/org/cinnamon/control-center/wacom/wacom-stylus-page.ui",
                                                objects,

--- a/panels/wacom/csd-wacom-device.c
+++ b/panels/wacom/csd-wacom-device.c
@@ -22,7 +22,7 @@
 #include "config.h"
 
 #include <glib.h>
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 #include <gtk/gtk.h>
 #include <gdk/gdk.h>
 #include <gdk/gdkx.h>

--- a/panels/wacom/wacom-module.c
+++ b/panels/wacom/wacom-module.c
@@ -23,7 +23,7 @@
 
 #include "cc-wacom-panel.h"
 
-#include <glib/gi18n-lib.h>
+#include <glib/gi18n.h>
 
 void
 g_io_module_load (GIOModule *module)


### PR DESCRIPTION
Repeated calls to gtk_builder_set_translation_domain() and inclusions of glib-internal calls can be avoided easily, when the textdomain is setup properly during initialization of the corresponding module.