### PR TITLE
configure: add option to disable installation of shell

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -321,6 +321,16 @@ PKG_CHECK_MODULES(ISOCODES, iso-codes)
 AC_DEFINE_UNQUOTED([ISO_CODES_PREFIX],["`$PKG_CONFIG --variable=prefix iso-codes`"],[ISO codes prefix])
 ISO_CODES=iso-codes
 
+AC_ARG_ENABLE(shell, AC_HELP_STRING([--enable-shell], [enable panel debugging shell]),
+              [case "${enableval}" in
+                      yes) enable_shell=yes ;;
+                      no) enable_shell=no ;;
+                      *) AC_MSG_ERROR(bad value ${enableval} for --enable-shell) ;;
+              esac],
+              [enable_shell=no]) dnl disabled by default
+
+AM_CONDITIONAL(BUILD_SHELL, [test x$enable_shell = xyes])
+
 dnl ==============================================
 dnl End: Check that we meet the  dependencies
 dnl ==============================================

--- a/shell/Makefile.am
+++ b/shell/Makefile.am
@@ -2,7 +2,9 @@ AM_CPPFLAGS =					\
 	-I$(top_srcdir)				\
 	$(SHELL_CFLAGS)
 
+if BUILD_SHELL
 bin_PROGRAMS = cinnamon-control-center
+endif
 
 MARSHAL_FILES = cc-shell-marshal.c cc-shell-marshal.h
 BUILT_SOURCES = $(MARSHAL_FILES)
@@ -85,6 +87,7 @@ menu_DATA = cinnamoncc.menu
 cinnamoncc.menu: cinnamoncc.menu.in
 	$(AM_V_GEN) cat $< | sed 's,@applicationsdir@,$(datadir)/applications/,' > $@
 
+if BUILD_SHELL
 uidir = $(pkgdatadir)/ui
 ui_DATA = shell.ui
 
@@ -92,6 +95,7 @@ sysdir = $(datadir)/applications
 sys_in_files = cinnamon-control-center.desktop.in
 sys_DATA = $(sys_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
+endif
 
 directorydir = $(datadir)/desktop-directories
 directory_in_files = cinnamoncc.directory.in


### PR DESCRIPTION
The binary for /usr/bin/cinnamon-control-center is not usually needed by users, as the control center is managed through cinnamon-settings. It exists for convenience/debugging purposes for developer use only, and should not be enabled by default for general use.

cf. https://github.com/linuxmint/Cinnamon/pull/7382#issuecomment-374894901