### PR TITLE
Stop requiring NetworkManager.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,10 +157,6 @@ if test "x$enable_networkmanager" = xyes; then
 
     if test x${have_networkmanager} = xyes; then
       AC_DEFINE(HAVE_NETWORK_MANAGER, 1, [Define to 1 if NetworkManager is available])
-      NM_VPN_CONFIG_DIR=`$PKG_CONFIG --variable configdir NetworkManager`/VPN
-      NM_VPN_MODULE_DIR=`$PKG_CONFIG --variable plugindir NetworkManager`
-      AC_SUBST(NM_VPN_CONFIG_DIR)
-      AC_SUBST(NM_VPN_MODULE_DIR)
     fi
 
     if test x${have_nma_18} = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -155,10 +155,6 @@ if test "x$enable_networkmanager" = xyes; then
 
     AC_DEFINE(BUILD_NETWORK, 1, [Define to 1 to build the Network panel])
 
-    if test x${have_networkmanager} = xyes; then
-      AC_DEFINE(HAVE_NETWORK_MANAGER, 1, [Define to 1 if NetworkManager is available])
-    fi
-
     if test x${have_nma_18} = xyes; then
       AC_DEFINE(HAVE_NMA_18, 1, [Define to 1 if libnma ist >= 1.8.0])
     fi

--- a/panels/network/connection-editor/Makefile.am
+++ b/panels/network/connection-editor/Makefile.am
@@ -39,9 +39,7 @@ libconnection_editor_la_CPPFLAGS = 		\
 	$(PANEL_CFLAGS)				\
 	-I$(srcdir)/../wireless-security	\
 	$(NETWORK_PANEL_CFLAGS) 		\
-        $(NETWORK_MANAGER_CFLAGS)		\
-	-DNM_VPN_CONFIG_DIR=\""$(NM_VPN_CONFIG_DIR)"\" \
-	-DNM_VPN_MODULE_DIR=\""$(NM_VPN_MODULE_DIR)"\"
+        $(NETWORK_MANAGER_CFLAGS)
 
 libconnection_editor_la_LIBADD = 		\
 	$(builddir)/../wireless-security/libwireless-security.la \


### PR DESCRIPTION
We don't actually use NM_VPN_CONFIG_DIR and NM_VPN_MODULE_DIR, along with the
corresponding configure check.