### PR TITLE
Fix network settings, fixes e.g. eduroam

### DIFF
--- a/panels/network/cc-network-panel.c
+++ b/panels/network/cc-network-panel.c
@@ -264,8 +264,7 @@ cc_network_panel_class_init (CcNetworkPanelClass *klass)
         object_class->dispose = cc_network_panel_dispose;
         object_class->finalize = cc_network_panel_finalize;
 
-        //FIXME: Causing warnings
-        //g_object_class_override_property (object_class, PROP_PARAMETERS, "parameters");
+        g_object_class_override_property (object_class, PROP_PARAMETERS, "parameters");
 }
 
 static NetObject *

--- a/shell/cc-shell.c
+++ b/shell/cc-shell.c
@@ -172,7 +172,8 @@ cc_shell_set_active_panel (CcShell *shell,
 /**
  * cc_shell_set_active_panel_from_id:
  * @shell: A #CcShell
- * @id: the ID of the panel to set as active
+ * @id: The ID of the panel to set as active
+ * @parameters: A #GVariant with additional parameters
  * @error: A #GError
  *
  * Find a panel corresponding to the specified id and set it as active.
@@ -182,7 +183,7 @@ cc_shell_set_active_panel (CcShell *shell,
 gboolean
 cc_shell_set_active_panel_from_id (CcShell      *shell,
                                    const gchar  *id,
-                                   const gchar **argv,
+                                   GVariant     *parameters,
                                    GError      **error)
 {
   CcShellClass *class;
@@ -201,7 +202,7 @@ cc_shell_set_active_panel_from_id (CcShell      *shell,
     }
   else
     {
-      return class->set_active_panel_from_id (shell, id, argv, error);
+      return class->set_active_panel_from_id (shell, id, parameters, error);
     }
 }
 

--- a/shell/cc-shell.h
+++ b/shell/cc-shell.h
@@ -86,7 +86,7 @@ struct _CcShellClass
   /* vfuncs */
   gboolean    (*set_active_panel_from_id) (CcShell      *shell,
                                            const gchar  *id,
-                                           const gchar **argv,
+                                           GVariant     *parameters,
                                            GError      **error);
   GtkWidget * (*get_toplevel)             (CcShell      *shell);
   void        (*embed_widget_in_header)   (CcShell      *shell,
@@ -100,7 +100,7 @@ void            cc_shell_set_active_panel         (CcShell      *shell,
                                                    CcPanel      *panel);
 gboolean        cc_shell_set_active_panel_from_id (CcShell      *shell,
                                                    const gchar  *id,
-                                                   const gchar **argv,
+                                                   GVariant     *parameters,
                                                    GError      **error);
 GtkWidget *     cc_shell_get_toplevel             (CcShell      *shell);
 

--- a/shell/cinnamon-control-center.c
+++ b/shell/cinnamon-control-center.c
@@ -178,7 +178,7 @@ get_icon_name_from_g_icon (GIcon *gicon)
 static gboolean
 activate_panel (CinnamonControlCenter *shell,
                 const gchar        *id,
-		const gchar       **argv,
+                GVariant           *parameters,
                 const gchar        *desktop_file,
                 const gchar        *name,
                 GIcon              *gicon)
@@ -236,7 +236,7 @@ activate_panel (CinnamonControlCenter *shell,
     }
 
   /* create the panel plugin */
-  priv->current_panel = g_object_new (panel_type, "shell", shell, "argv", argv, NULL);
+  priv->current_panel = g_object_new (panel_type, "shell", shell, "parameters", parameters, NULL);
   cc_shell_set_active_panel (CC_SHELL (shell), CC_PANEL (priv->current_panel));
   gtk_widget_show (priv->current_panel);
 
@@ -967,7 +967,7 @@ _shell_embed_widget_in_header (CcShell      *shell,
 static gboolean
 _shell_set_active_panel_from_id (CcShell      *shell,
                                  const gchar  *start_id,
-				 const gchar **argv,
+                                 GVariant     *parameters,
                                  GError      **err)
 {
   GtkTreeIter iter;
@@ -978,10 +978,10 @@ _shell_set_active_panel_from_id (CcShell      *shell,
   CinnamonControlCenterPrivate *priv = CINNAMON_CONTROL_CENTER (shell)->priv;
   GtkWidget *old_panel;
 
-  /* When loading the same panel again, just set the argv */
+  /* When loading the same panel again, just set its parameters */
   if (g_strcmp0 (priv->current_panel_id, start_id) == 0)
     {
-      g_object_set (G_OBJECT (priv->current_panel), "argv", argv, NULL);
+      g_object_set (G_OBJECT (priv->current_panel), "parameters", parameters, NULL);
       return TRUE;
     }
 
@@ -1035,7 +1035,7 @@ _shell_set_active_panel_from_id (CcShell      *shell,
     {
       g_warning ("Could not find settings panel \"%s\"", start_id);
     }
-  else if (activate_panel (CINNAMON_CONTROL_CENTER (shell), start_id, argv, desktop,
+  else if (activate_panel (CINNAMON_CONTROL_CENTER (shell), start_id, parameters, desktop,
                            name, gicon) == FALSE)
     {
       /* Failed to activate the panel for some reason */

--- a/shell/control-center.c
+++ b/shell/control-center.c
@@ -128,15 +128,22 @@ application_command_line_cb (GApplication  *application,
     {
       const char *start_id;
       GError *err = NULL;
+      GVariant *parameters;
+      GVariantBuilder *builder;
+      int i;
 
       start_id = start_panels[0];
 
       if (start_panels[1])
-	g_debug ("Extra argument: %s", start_panels[1]);
+        g_debug ("Extra argument: %s", start_panels[1]);
       else
-	g_debug ("No extra argument");
+        g_debug ("No extra argument");
 
-      if (!cc_shell_set_active_panel_from_id (CC_SHELL (shell), start_id, (const gchar**)start_panels+1, &err))
+      builder = g_variant_builder_new (G_VARIANT_TYPE ("av"));
+      for (i = 1; start_panels[i] != NULL; i++)
+        g_variant_builder_add (builder, "v", g_variant_new_string (start_panels[i]));
+      parameters = g_variant_builder_end (builder);
+      if (!cc_shell_set_active_panel_from_id (CC_SHELL (shell), start_id, parameters, &err))
         {
           g_warning ("Could not load setting panel \"%s\": %s", start_id,
                      (err) ? err->message : "Unknown error");


### PR DESCRIPTION
Backports from almost 5 years ago introduced a bug, which causes problems
with some networks as eduroam. You have to manually configure those
networks, because the configuration dialog does not pop up.

This pull request backports the rest from gnome-control-center to fix
this issue. The backported commits are:
* https://gitlab.gnome.org/GNOME/gnome-control-center/commit/9977bb200ea66b2e8ee1d52d0400c4e27bf4b352
* https://gitlab.gnome.org/GNOME/gnome-control-center/commit/4e42a3613341cdbeb7954da53d15de1aa155d0db

Fixes https://github.com/linuxmint/cinnamon/issues/3623 and https://github.com/linuxmint/cinnamon/issues/7837