### PR TITLE
display: Clean up a couple labels in ui file

### DIFF
--- a/panels/display/display-capplet.ui
+++ b/panels/display/display-capplet.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkListStore" id="available_launcher_placement_store">
     <columns>
       <!-- column-name MONITOR_PREVIEW -->
@@ -11,6 +12,9 @@
   </object>
   <object class="GtkWindow" id="window1">
     <property name="can_focus">False</property>
+    <child>
+      <placeholder/>
+    </child>
     <child>
       <object class="GtkVBox" id="display-panel">
         <property name="visible">True</property>
@@ -54,10 +58,10 @@
                           <object class="GtkLabel" id="current_monitor_label">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xalign">0</property>
                             <property name="xpad">10</property>
                             <property name="ypad">5</property>
                             <property name="label" translatable="yes">Monitor</property>
+                            <property name="xalign">0</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
                             </attributes>
@@ -94,7 +98,6 @@
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                            <property name="use_action_appearance">False</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -133,16 +136,31 @@
                         <property name="column_spacing">12</property>
                         <property name="row_spacing">6</property>
                         <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
                           <object class="GtkLabel" id="label2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xalign">1</property>
                             <property name="label" translatable="yes">_Resolution</property>
                             <property name="use_underline">True</property>
                             <property name="mnemonic_widget">resolution_combo</property>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
                             <property name="x_options">GTK_FILL</property>
@@ -153,13 +171,10 @@
                           <object class="GtkLabel" id="label5">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="xalign">1</property>
                             <property name="label" translatable="yes">R_otation</property>
                             <property name="use_underline">True</property>
                             <property name="mnemonic_widget">rotation_combo</property>
-                            <style>
-                              <class name="dim-label"/>
-                            </style>
+                            <property name="xalign">1</property>
                           </object>
                           <packing>
                             <property name="top_attach">1</property>
@@ -252,11 +267,11 @@
                   <object class="GtkLabel" id="clone_resolution_warning_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">Note: may limit resolution options</property>
-                    <attributes>
-                      <attribute name="style" value="italic"/>
-                    </attributes>
+                    <property name="xalign">0</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
                   </object>
                   <packing>
                     <property name="expand">False</property>


### PR DESCRIPTION
Get rid of a couple dim-labels and usages of italics

This looks like more changes then it actually is because it was saved from a newer Glade version