### PR TITLE
Add ifdefs to prevent undefined reference to modem functions in network panel

### DIFF
--- a/panels/network/cc-network-panel.c
+++ b/panels/network/cc-network-panel.c
@@ -29,7 +29,9 @@
 #include <NetworkManager.h>
 
 #include "net-device.h"
+#ifdef BUILD_MODEM
 #include "net-device-mobile.h"
+#endif
 #include "net-device-wifi.h"
 #include "net-device-ethernet.h"
 #include "net-object.h"
@@ -651,9 +653,11 @@ panel_add_device (CcNetworkPanel *panel, NMDevice *device)
         case NM_DEVICE_TYPE_ETHERNET:
                 device_g_type = NET_TYPE_DEVICE_ETHERNET;
                 break;
+        #ifdef BUILD_MODEM
         case NM_DEVICE_TYPE_MODEM:
                 device_g_type = NET_TYPE_DEVICE_MOBILE;
                 break;
+        #endif
         case NM_DEVICE_TYPE_WIFI:
                 device_g_type = NET_TYPE_DEVICE_WIFI;
                 break;


### PR DESCRIPTION
Fixes #254 . There is an issue with `-Dnetworkmanager=true -Dmodemmanager=false` giving an undefined reference because the modem header is included and used by the network panel source file.