### PR TITLE
network panel: Don't try to rebuild the ui during shutdown.

### DIFF
--- a/panels/network/cc-network-panel.c
+++ b/panels/network/cc-network-panel.c
@@ -228,9 +228,9 @@ cc_network_panel_dispose (GObject *object)
                 g_cancellable_cancel (priv->cancellable);
 
         g_clear_object (&priv->cancellable);
-        g_clear_object (&priv->builder);
         g_clear_object (&priv->client);
         g_clear_object (&priv->modem_manager);
+        g_clear_object (&priv->builder);
 
         G_OBJECT_CLASS (cc_network_panel_parent_class)->dispose (object);
 }

--- a/panels/network/net-device.c
+++ b/panels/network/net-device.c
@@ -327,6 +327,11 @@ net_device_get_valid_connections (NetDevice *device)
         filtered = nm_device_filter_connections (net_device_get_nm_device (device), all);
 
         active_connection = nm_device_get_active_connection (net_device_get_nm_device (device));
+
+        if (!NM_IS_ACTIVE_CONNECTION (active_connection)) {
+            return NULL;
+        }
+
         active_uuid = active_connection ? nm_active_connection_get_uuid (active_connection) : NULL;
 
         valid = NULL;


### PR DESCRIPTION
And don't destroy the ui before the nm client is disposed of.

Fixes #269