### PR TITLE
small debian packaging improve

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -67,7 +67,6 @@ Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends}
 Recommends: cinnamon-control-center (>= ${source:Version})
-Provides: cinnamon-capplets-data
 Description: configuration applets for Cinnamon - data files
  This package contains data files (icons, pixmaps, locales files) needed by
  the configuration applets in the cinnamon-control-center package.

--- a/debian/control
+++ b/debian/control
@@ -53,8 +53,7 @@ Depends:
 Recommends:
  cinnamon-l10n,
  iso-codes,
- mesa-utils,
- mousetweaks
+ mesa-utils
 Suggests: x11-xserver-utils
 Description: utilities to configure the Cinnamon desktop
  This package contains configuration applets for the Cinnamon desktop,

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Build-Depends:
  libcinnamon-desktop-dev (>= 4.8),
  libcinnamon-menu-3-dev,
  libcolord-dev,
- libdbus-1-dev (>= 0.32),
  libgdk-pixbuf2.0-dev (>= 2.23.0),
  libglib2.0-dev (>= 2.44.0),
  libgnomekbd-dev,

--- a/debian/copyright
+++ b/debian/copyright
@@ -45,21 +45,13 @@ Copyright: 2013, Aleksander Morgado <aleksander@gnu.org>
            2003, The free software foundation, inc
 License: GPL-2+
 
-Files: panels/wacom/calibrator/COPYING
-       panels/wacom/calibrator/calibrator.c
-       panels/wacom/calibrator/calibrator.h
-       panels/wacom/calibrator/gui_gtk.c
-       panels/wacom/calibrator/gui_gtk.h
-       panels/wacom/calibrator/main.c
+Files: panels/wacom/calibrator/*
 Copyright: 2009, Soren Hauberg
-           2009, Tias Guns
-           2010, Tias Guns <tias@ulyssis.org> and others
+           2009-2010, Tias Guns <tias@ulyssis.org> and others
 License: Expat
 
-Files: panels/display/cc-rr-labeler.c
-       panels/display/cc-rr-labeler.h
-       panels/display/scrollarea.c
-       panels/display/scrollarea.h
+Files: panels/display/cc-display-labeler.c
+       panels/display/cc-display-labeler.h
        panels/network/wireless-security/nm-default.h
        panels/online-accounts/cc-online-accounts-panel.c
        panels/online-accounts/cc-online-accounts-panel.h
@@ -80,6 +72,7 @@ License: public-domain
 
 Files: debian/*
 Copyright: 2014, Maximiliano Curia <maxy@debian.org>
+           2015-2022, Debian Cinnamon Team <debian-cinnamon@lists.debian.org>
 License: GPL-2+
 
 License: Expat


### PR DESCRIPTION
d/control:
- remove libdbus-1-dev build-dep, not needed anymore
- remove Provides cinnamon-capplets-data, not needed anymore