### PR TITLE
meson: fix installation of symlinks

### DIFF
--- a/install-scripts/desktop-file-links.py
+++ b/install-scripts/desktop-file-links.py
@@ -4,16 +4,11 @@ import os
 import subprocess
 
 # Symlinks desktop files to c-c-c's panel dir so the cinnamon-control-center binary can find the plugins.
-dest = os.environ.get('DESTDIR')
+destdir_prefix = os.environ.get('MESON_INSTALL_DESTDIR_PREFIX')
 prefix = os.environ.get('MESON_INSTALL_PREFIX')
 
-if dest:
-    root = dest
-else:
-    root = "/"
-
-source_location = os.path.join(root, prefix[1:], "share", "applications")
-target_location = os.path.join(root, prefix[1:], "share", "cinnamon-control-center", "panels")
+source_location = os.path.join(prefix, "share", "applications")
+target_location = os.path.join(destdir_prefix, "share", "cinnamon-control-center", "panels")
 
 links = [
     "cinnamon-color-panel.desktop",

--- a/install-scripts/meson.build
+++ b/install-scripts/meson.build
@@ -1,1 +1,15 @@
-meson.add_install_script('desktop-file-links.py')
+if meson.version().version_compare('>=0.61.0')
+  foreach link: [
+    'cinnamon-color-panel.desktop',
+    'cinnamon-display-panel.desktop',
+    'cinnamon-network-panel.desktop',
+    'cinnamon-wacom-panel.desktop',
+  ]
+    install_symlink(link,
+      install_dir: panel_def_dir,
+      pointing_to: '../../applications' / link
+    )
+  endforeach
+else
+  meson.add_install_script('desktop-file-links.py')
+endif


### PR DESCRIPTION
Fixes regression in commit 5aa5fab4348de4496efe9ec0b5faa20be234d56e. The created symlinks always considered the directory to be installed to, and created absolute symlinks pointing from the source to the destination. This is wrong, because while the source needs to be installed *into* the directory to be installed to, the destination needs to not include the $DESTDIR.

There are also some sub-optimal design points around scripting the install prefix. Particularly, Meson has a dedicated variable for the combination of DESTDIR + prefix, so use that instead of manually slicing up the prefix so that `os.path.join` won't drop the DESTDIR. The other solution would be to acknowledge that DESTDIR (at least on non-Windows systems) uses string concatenation, not path-joining semantics, but... Meson already supplies this pre-done, so why bother?

Fixes #285