### PR TITLE
meson: fix regression in installing with some panels disabled

### DIFF
--- a/install-scripts/meson.build
+++ b/install-scripts/meson.build
@@ -1,10 +1,18 @@
+links = [
+  'cinnamon-display-panel.desktop',
+]
+if colord.found()
+  links += ['cinnamon-color-panel.desktop']
+endif
+if libnm.found()
+  links += ['cinnamon-network-panel.desktop']
+endif
+if libwacom.found()
+  links += ['cinnamon-wacom-panel.desktop']
+endif
+
 if meson.version().version_compare('>=0.61.0')
-  foreach link: [
-    'cinnamon-color-panel.desktop',
-    'cinnamon-display-panel.desktop',
-    'cinnamon-network-panel.desktop',
-    'cinnamon-wacom-panel.desktop',
-  ]
+  foreach link: links
     install_symlink(link,
       install_dir: panel_def_dir,
       pointing_to: '../../applications' / link


### PR DESCRIPTION
In commit ca95ce7dfc4872ecef88b0074d2bee8f097d0394 some symlink creation is handled for all panels, without first checking whether those panels are installed.

Make sure to only try installing those symlinks if their accompanying options/dependencies are enabled/found.

Fixes #289