### PR TITLE
build: add missing gio-unix-2.0 dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ cinn_menu   = dependency('libcinnamon-menu-3.0')
 
 gtk         = dependency('gtk+-3.0',        version: '>=3.16.0')
 glib        = dependency('glib-2.0',        version: '>=2.44.0')
+gio_unix    = dependency('gio-unix-2.0',    version: '>=2.44.0')
 libgnomekbd = dependency('libgnomekbd',     version: '>=3.0.0')
 libgnomekbdui=dependency('libgnomekbdui',   version: '>=3.0.0')
 libnotify   = dependency('libnotify',       version: '>=0.7.3')

--- a/shell/meson.build
+++ b/shell/meson.build
@@ -52,6 +52,7 @@ controlcenter = executable('cinnamon-control-center',
   include_directories: rootInclude,
   dependencies: [
     gtk,
+    gio_unix,
     cinn_menu,
     libx11,
     libnotify


### PR DESCRIPTION
The Nix package manager used by NixOS (and available on all unix systems), uses a sandboxed environment where it is not possible to have global building dependencies. Without this change the build with fails with:

```
[15/124] Compiling C object shell/cinnamon-control-center.p/cinnamon-control-center.c.o
FAILED: shell/cinnamon-control-center.p/cinnamon-control-center.c.o 
gcc -Ishell/cinnamon-control-center.p -Ishell -I../shell -I. -I.. -I/nix/store/qbvaw0nl5rvmwm6ljsmvq7ciazqvcd2j-gtk+3-3.24.34-dev/include/gtk-3.0 -I/nix/store/mkn4f22mpfk654j46r5644fvg73cxz82-atk-2.38.0-dev/include/atk-1.0 -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include -I/nix/store/0a9b4bv93s2b94q0fa2h4r0m55qy92fx-glib-2.72.3-dev/include/glib-2.0 -I/nix/store/i4k2ahrb0rzr7f2ni02nljcffawvpqpg-glib-2.72.3/lib/glib-2.0/include -I/nix/store/vxkj5z9f1fb1vpygxxxpncy9x1aay4k7-cairo-1.16.0-dev/include/cairo -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include/freetype2 -I/nix/store/ifapwp4j01rj1800abwq7xqc5ymr6cv6-freetype-2.12.1-dev/include -I/nix/store/v99pf1pni85bxccfn1yhy4fanq4idagw-gdk-pixbuf-2.42.8-dev/include/gdk-pixbuf-2.0 -I/nix/store/x61p9rbkrh362sl3xxzhw1qvnlklylam-pango-1.50.7-dev/include/pango-1.0 -I/nix/store/qpglawyvc4ybhqkkz368zlpq1gw00h44-harfbuzz-3.3.2-dev/include/harfbuzz -I/nix/store/b8ll8n9jgdmb7v61dli51cq3rqxfw5gr-cinnamon-menus-5.4.0/include/cinnamon-menus-3.0 -I/nix/store/9wcm2vn1kdg725cximpvzaalx89bzgmf-xorgproto-2021.5/include -I/nix/store/xqahkgsh844in1clizx358d6iim0kp32-libX11-1.7.2-dev/include -I/nix/store/xnsdrm1rdj6ph4dyhyxx433bcm4bc6hv-libnotify-0.7.12-dev/include -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wno-strict-aliasing -Wno-sign-compare -Wno-deprecated-declarations -Wno-deprecated -Wno-declaration-after-statement -DGLIB_DISABLE_DEPRECATION_WARNINGS -MD -MQ shell/cinnamon-control-center.p/cinnamon-control-center.c.o -MF shell/cinnamon-control-center.p/cinnamon-control-center.c.o.d -o shell/cinnamon-control-center.p/cinnamon-control-center.c.o -c ../shell/cinnamon-control-center.c
../shell/cinnamon-control-center.c:28:10: fatal error: gio/gdesktopappinfo.h: No such file or directory
   28 | #include <gio/gdesktopappinfo.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[16/124] Compiling C object shell/cinnamon-control-center.p/cc-shell-nav-bar.c.o
[17/124] Compiling C object shell/cinnamon-control-center.p/control-center.c.o
../shell/control-center.c: In function 'help_activated':
../shell/control-center.c:183:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  183 |   if (panel)
      |   ^~
../shell/control-center.c:185:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  185 |     if (!g_strcmp0(g_getenv("XDG_CURRENT_DESKTOP"), "Unity"))
      |     ^~
[18/124] Compiling C object panels/color/libcolor.so.p/cc-color-panel.c.o
ninja: build stopped: subcommand failed.
```

https://github.com/linuxmint/cinnamon-control-center/blob/ae3793499c411f71a592865ce13bf875043a4ce1/shell/cinnamon-control-center.c#L28

See also 

- https://github.com/NixOS/nixpkgs/issues/36468

Thanks for reviewing this :-)