### PR TITLE
region panel: add keys removed from libgnomekbd's API in v3.28

### DIFF
--- a/panels/region/cinnamon-region-panel-xkb.c
+++ b/panels/region/cinnamon-region-panel-xkb.c
@@ -36,6 +36,12 @@
 
 #define GKBD_CONFIG_KEY_LOAD_EXTRA_ITEMS "load-extra-items"
 
+// These were removed from the API of libgnomekbd in version 3.28
+const gchar GKBD_DESKTOP_CONFIG_KEY_DEFAULT_GROUP[] = "default-group";
+const gchar GKBD_DESKTOP_CONFIG_KEY_GROUP_PER_WINDOW[] = "group-per-window";
+const gchar GKBD_KEYBOARD_CONFIG_KEY_LAYOUTS[] = "layouts";
+const gchar GKBD_KEYBOARD_CONFIG_KEY_OPTIONS[] = "options";
+
 XklEngine *engine;
 XklConfigRegistry *config_registry;
 

--- a/panels/region/cinnamon-region-panel-xkb.h
+++ b/panels/region/cinnamon-region-panel-xkb.h
@@ -36,6 +36,11 @@ extern GSettings *xkb_keyboard_settings;
 extern GSettings *xkb_desktop_settings;
 extern GkbdKeyboardConfig initial_config;
 
+extern const gchar GKBD_DESKTOP_CONFIG_KEY_DEFAULT_GROUP[];
+extern const gchar GKBD_DESKTOP_CONFIG_KEY_GROUP_PER_WINDOW[];
+extern const gchar GKBD_KEYBOARD_CONFIG_KEY_LAYOUTS[];
+extern const gchar GKBD_KEYBOARD_CONFIG_KEY_OPTIONS[];
+
 extern void setup_xkb_tabs (GtkBuilder * dialog);
 
 extern void xkb_layouts_fill_selected_tree (GtkBuilder * dialog);


### PR DESCRIPTION
While working myself through #288, libgnomekbd got updated to v3.28 and removed some `extern` declarations from their public headers.
I decided to redefine them in `cinnamon-region-panel-xkb.c` instead of just adding `extern` declarations to avoid another patch if the definitions in libgnomekbd are changed to `static`.