### PR TITLE
display panel: fallback if no preferred mode is set

### DIFF
--- a/panels/display/cc-display-arrangement.c
+++ b/panels/display/cc-display-arrangement.c
@@ -113,7 +113,10 @@ get_scaled_geometry (CcDisplayConfig  *config,
   else
     {
       cc_display_monitor_get_geometry (output, x, y, NULL, NULL);
-      cc_display_mode_get_resolution (cc_display_monitor_get_preferred_mode (output), w, h);
+      CcDisplayMode *mode = cc_display_monitor_get_preferred_mode(output);
+      if (!mode)
+        mode = CC_DISPLAY_MODE (cc_display_monitor_get_modes(output)->data);
+      cc_display_mode_get_resolution (mode, w, h);
     }
 
   if (cc_display_config_is_layout_logical (config))


### PR DESCRIPTION
If a monitor has no preferred mode, for example due to an issue in
muffin, get_scaled_geometry did segfault when the monitor is inactive.

It was inactive because the chosen configuration wasn't shown as active
mode either.

This resulted in not being able to open the display panel to even change
to a working configuration without compiling cinnamon-control-center
myself.

With this patch, the panel does open even without preferred mode on a
monitor.

Closes #288 