### PR TITLE
l10n: respect localedir option from meson again

### DIFF
--- a/panels/color/cc-color-panel.c
+++ b/panels/color/cc-color-panel.c
@@ -2513,7 +2513,7 @@ void
 cc_color_panel_register (GIOModule *module)
 {
   textdomain (GETTEXT_PACKAGE);
-  bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+  bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
   cc_color_panel_register_type (G_TYPE_MODULE (module));
   g_io_extension_point_implement (CC_SHELL_PANEL_EXTENSION_POINT,

--- a/panels/common/list-languages.c
+++ b/panels/common/list-languages.c
@@ -13,7 +13,7 @@ int main (int argc, char **argv)
 
 	setlocale (LC_ALL, NULL);
 	textdomain (GETTEXT_PACKAGE);
-	bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+	bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 
 	g_type_init ();

--- a/panels/datetime/cc-datetime-panel.c
+++ b/panels/datetime/cc-datetime-panel.c
@@ -1175,7 +1175,7 @@ void
 cc_date_time_panel_register (GIOModule *module)
 {
   textdomain (GETTEXT_PACKAGE);
-  bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+  bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 
   cc_date_time_panel_register_type (G_TYPE_MODULE (module));

--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -1164,7 +1164,7 @@ void
 cc_display_panel_register (GIOModule *module)
 {
   textdomain (GETTEXT_PACKAGE);
-  bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+  bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 
   cc_display_panel_register_type (G_TYPE_MODULE (module));

--- a/panels/network/cc-network-panel.c
+++ b/panels/network/cc-network-panel.c
@@ -1347,7 +1347,7 @@ void
 cc_network_panel_register (GIOModule *module)
 {
         textdomain (GETTEXT_PACKAGE);
-        bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+        bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
         bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
         cc_network_panel_register_type (G_TYPE_MODULE (module));
         g_io_extension_point_implement (CC_SHELL_PANEL_EXTENSION_POINT,

--- a/panels/online-accounts/cc-online-accounts-panel.c
+++ b/panels/online-accounts/cc-online-accounts-panel.c
@@ -969,7 +969,7 @@ void
 cc_goa_panel_register (GIOModule *module)
 {
         textdomain (GETTEXT_PACKAGE);
-        bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+        bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
         bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
         cc_goa_panel_register_type (G_TYPE_MODULE (module));
         g_io_extension_point_implement (CC_SHELL_PANEL_EXTENSION_POINT,

--- a/panels/region/cc-region-panel.c
+++ b/panels/region/cc-region-panel.c
@@ -97,7 +97,7 @@ void
 cc_region_panel_register (GIOModule * module)
 {
 	textdomain (GETTEXT_PACKAGE);
-	bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+	bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	cc_region_panel_register_type (G_TYPE_MODULE (module));
 	g_io_extension_point_implement (CC_SHELL_PANEL_EXTENSION_POINT,

--- a/panels/wacom/cc-wacom-panel.c
+++ b/panels/wacom/cc-wacom-panel.c
@@ -711,7 +711,7 @@ cc_wacom_panel_register (GIOModule *module)
 {
     cc_wacom_panel_register_type (G_TYPE_MODULE (module));
     textdomain (GETTEXT_PACKAGE);
-    bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+    bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
     bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
     g_io_extension_point_implement (CC_SHELL_PANEL_EXTENSION_POINT,
                     CC_TYPE_WACOM_PANEL, "wacom", 0);

--- a/shell/control-center.c
+++ b/shell/control-center.c
@@ -242,7 +242,7 @@ main (int argc, char **argv)
   GtkApplication *application;
   int status;
 
-  bindtextdomain (GETTEXT_PACKAGE, "/usr/share/locale");
+  bindtextdomain (GETTEXT_PACKAGE, LOCALE_DIR);
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
   textdomain (GETTEXT_PACKAGE);
 


### PR DESCRIPTION
Looks like this is caused by historical reasons (translations are likely installed in `/usr/share/cinnamon/locale` [previously](https://github.com/linuxmint/cinnamon-control-center/commit/9bc25af2873eaf99995733aab584838234720c3a)). But since translations are now installed back to `/usr/share/locale`, we can give this a try again.