### PR TITLE
Fix optional wayland handling in cc-display-panel

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -196,6 +196,7 @@ final_message = [ '',
   '** Colord support (Color management panel)         : @0@'.format(colord.found()),
   '** Wacom support (Wacom panel)                     : @0@'.format(libwacom.found()),
   '** Online-Accounts support (Online-Accounts panel) : @0@'.format(goa.found()),
+  '** Wayland support                                 : @0@'.format(cc.has_header('gdk/gdkwayland.h', dependencies: gtk)),
   '',
 ]
 message('\n'.join(final_message))

--- a/panels/display/cc-display-panel.c
+++ b/panels/display/cc-display-panel.c
@@ -28,7 +28,9 @@
 
 #include <libcinnamon-desktop/cdesktop-enums.h>
 #include <math.h>
+#ifdef GDK_WINDOWING_WAYLAND
 #include <gdk/gdkwayland.h>
+#endif
 
 #include <libupower-glib/upower.h>
 
@@ -114,7 +116,11 @@ struct _CcDisplayPanel
 
 CC_PANEL_REGISTER (CcDisplayPanel, cc_display_panel)
 
+#ifdef GDK_WINDOWING_WAYLAND
 #define WAYLAND_SESSION() (GDK_IS_WAYLAND_DISPLAY (gdk_display_get_default()))
+#else
+#define WAYLAND_SESSION() (FALSE)
+#endif
 
 static void update_bottom_buttons (CcDisplayPanel *panel);
 static void apply_current_configuration (CcDisplayPanel *self);


### PR DESCRIPTION
Add some missing `GDK_WINDOWING_WAYLAND` checks to fix compatibility with gtk+ built without wayland support.