### PR TITLE
network: Fix warning about missing cast to GtkWidget*

### DIFF
--- a/panels/network/connection-editor/net-connection-editor.c
+++ b/panels/network/connection-editor/net-connection-editor.c
@@ -845,7 +845,7 @@ net_connection_editor_new (GtkWindow        *parent_window,
         editor = g_object_new (NET_TYPE_CONNECTION_EDITOR, NULL);
 
         if (parent_window) {
-                editor->parent_window = g_object_ref (parent_window);
+                editor->parent_window = GTK_WIDGET (g_object_ref (parent_window));
                 gtk_window_set_transient_for (GTK_WINDOW (editor->window),
                                               parent_window);
         }


### PR DESCRIPTION
Based on https://github.com/GNOME/gnome-control-center/commit/167d11e2107e46b4621cf6fc370c5b191b4b7732