### PR TITLE
meson: remove CFLAGS that were carried over from decades ago and aren't needed

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -120,8 +120,6 @@ config.set_quoted('PANEL_DEF_DIR',        prefix / panel_def_dir)
 
 
 more_cflags = [
-  '-Wno-strict-aliasing',
-  '-Wno-sign-compare',
 ]
 
 if get_option('warning_level').to_int() >=2


### PR DESCRIPTION
These warnings don't trigger. They've stuck around across build systems somehow.