### PR TITLE
network: prevent redefinition error when building with musl libc

### DIFF
--- a/panels/network/wireless-security/utils.c
+++ b/panels/network/wireless-security/utils.c
@@ -20,11 +20,10 @@
  * Copyright 2007 - 2015 Red Hat, Inc.
  */
 
-#include "nm-default.h"
-
 #include <string.h>
 #include <netinet/ether.h>
 
+#include "nm-default.h"
 #include "utils.h"
 
 /**


### PR DESCRIPTION
musl libc has its own `ethhdr` struct that is always defined in <netinet/ether.h>. Normally, "nm-default.h" prevents the redefinition of `ethhdr` if that struct is already defined, but because "nm-default.h" comes before <netinet/ether.h>, it will define the struct, causing a redefinition error.

The patch for this comes from Void Linux, and I am a Chimera Linux packager.