### PR TITLE
network: Could not load editor VPN plugin warning

### DIFF
--- a/panels/network/connection-editor/ce-page-vpn.c
+++ b/panels/network/connection-editor/ce-page-vpn.c
@@ -93,10 +93,11 @@ load_vpn_plugin (CEPageVpn *page, NMConnection *connection)
 {
 	CEPage *parent = CE_PAGE (page);
         GtkWidget *ui_widget, *failure;
+        GError *err = NULL;
 
         page->editor = nm_vpn_editor_plugin_get_editor (page->plugin,
                                                         connection,
-                                                        NULL);
+                                                        &err);
         ui_widget = NULL;
         if (page->editor)
                 ui_widget = GTK_WIDGET (nm_vpn_editor_get_widget (page->editor));
@@ -104,6 +105,10 @@ load_vpn_plugin (CEPageVpn *page, NMConnection *connection)
 	if (!ui_widget) {
 		g_clear_object (&page->editor);
                 page->plugin = NULL;
+                g_warning ("Could not load editor VPN plugin for '%s' (%s).",
+                           nm_setting_vpn_get_service_type (nm_connection_get_setting_vpn (connection)),
+                           err ? err->message : "Unknown error");
+                g_error_free (err);
 		return;
 	}
         vpn_cinnamonify_editor (ui_widget);


### PR DESCRIPTION
Produces warning using the same format as nm-connection-editor when a VPN connection editor plugin cannot be loaded.
