### PR TITLE
Update Debian .deb control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -42,7 +42,6 @@ Depends:
  desktop-file-utils,
  gettext,
  libcinnamon-control-center1 (= ${binary:Version}),
- policykit-1-gnome,
  xdg-utils,
  ${misc:Depends},
  ${shlibs:Depends},


### PR DESCRIPTION
According to the new release of 22.1, https://www.linuxmint.com/rel_xia_whatsnew.php, policykit-1-gnome has been replaced. So I believe we can safely remove this package from the required package list.