### PR TITLE
Add iso-codes as debian build dependecy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Build-Depends:
  libx11-dev,
  libxml2-dev,
  meson,
+ iso-codes,
 Standards-Version: 3.9.8
 Homepage: https://www.github.com/linuxmint/cinnamon-control-center
 


### PR DESCRIPTION
- Debian builds are failing without iso-codes package