### PR TITLE
iso-codes: Remove unused build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,6 @@ Build-Depends:
  libx11-dev,
  libxml2-dev,
  meson,
- iso-codes,
 Standards-Version: 3.9.8
 Homepage: https://www.github.com/linuxmint/cinnamon-control-center
 

--- a/meson.build
+++ b/meson.build
@@ -37,12 +37,6 @@ upower_glib_dep = dependency('upower-glib', version: '>= 0.99.8')
 config.set('HAVE_X11_EXTENSIONS_XKB_H', cc.has_header('X11/extensions/XKB.h'))
 
 ###############################################################################
-# This is a hard-dependency for the region and user-accounts panels
-
-isocodes = dependency('iso-codes')
-config.set_quoted('ISO_CODES_PREFIX', isocodes.get_variable(pkgconfig: 'prefix'))
-
-###############################################################################
 # Network Manager stuff
 
 if get_option('networkmanager')


### PR DESCRIPTION
Completes this commit https://github.com/linuxmint/cinnamon-control-center/commit/9881cf7dc6c722a75344a1b42d951759d60e67b6