### PR TITLE
Fix for loading NmaCertChooser or NMACertChooser based VPN plugins

### DIFF
--- a/shell/cinnamon-control-center.c
+++ b/shell/cinnamon-control-center.c
@@ -39,6 +39,8 @@
 #include "cc-shell-model.h"
 #include "cc-shell-nav-bar.h"
 
+#include <libnma/nma-cert-chooser.h>
+
 G_DEFINE_TYPE (CinnamonControlCenter, cinnamon_control_center, CC_TYPE_SHELL)
 
 #define CONTROL_CENTER_PRIVATE(o) \
@@ -1390,6 +1392,12 @@ cinnamon_control_center_init (CinnamonControlCenter *self)
 
   /* load the available settings panels */
   setup_model (self);
+
+  /* Pre-register NMA widget types so they are in the global GType table and
+   * their get_type symbols are in RTLD_DEFAULT before any panel or VPN plugin
+   * is loaded.  Without this, VPN editor plugins that reference NmaCertChooser
+   * or NMACertChooser in their GtkBuilder UI fail with "Invalid object type" */
+  g_type_ensure (NMA_TYPE_CERT_CHOOSER);
 
   /* load the panels that are implemented as plugins */
   load_panel_plugins (self);

--- a/shell/meson.build
+++ b/shell/meson.build
@@ -55,7 +55,8 @@ controlcenter = executable('cinnamon-control-center',
     gio_unix,
     cinn_menu,
     libx11,
-    libnotify
+    libnotify,
+    libnma,
   ],
   link_with: libcinnamon_control_center,
   install: true


### PR DESCRIPTION
Explicitly link cinnamon-control-center against libnma.

Calls g_type_ensure(NMA_TYPE_CERT_CHOOSER) before load_panel_plugins(), ensuring both "NMACertChooser" and "NmaCertChooser" are registered in the global GType table before any VPN plugin is ever opened.

Fixes #319