### PR TITLE
display: snap monitors to aligned centers in the arrangement view

### DIFF
--- a/panels/display/cc-display-arrangement.c
+++ b/panels/display/cc-display-arrangement.c
@@ -416,6 +416,10 @@ find_best_snapping (CcDisplayConfig   *config,
       maybe_update_snap (snap_data, x1, y1, _x1, bottom_snap_pos, SNAP_DIR_BOTH, SNAP_DIR_Y, 0);
       maybe_update_snap (snap_data, x1, y1, _x2 - w, bottom_snap_pos, SNAP_DIR_BOTH, SNAP_DIR_Y, 0);
 
+      /* Centers aligned, stacked on the top/bottom */
+      maybe_update_snap (snap_data, x1, y1, _x1 + _w / 2 - w / 2, top_snap_pos, SNAP_DIR_BOTH, SNAP_DIR_Y, 0);
+      maybe_update_snap (snap_data, x1, y1, _x1 + _w / 2 - w / 2, bottom_snap_pos, SNAP_DIR_BOTH, SNAP_DIR_Y, 0);
+
       /* Top/bottom edge identical on the left */
       maybe_update_snap (snap_data, x1, y1, left_snap_pos, _y1, SNAP_DIR_BOTH, SNAP_DIR_X, 0);
       maybe_update_snap (snap_data, x1, y1, left_snap_pos, _y2 - h, SNAP_DIR_BOTH, SNAP_DIR_X, 0);
@@ -423,6 +427,10 @@ find_best_snapping (CcDisplayConfig   *config,
       /* Top/bottom edge identical on the right */
       maybe_update_snap (snap_data, x1, y1, right_snap_pos, _y1, SNAP_DIR_BOTH, SNAP_DIR_X, 0);
       maybe_update_snap (snap_data, x1, y1, right_snap_pos, _y2 - h, SNAP_DIR_BOTH, SNAP_DIR_X, 0);
+
+      /* Centers aligned, side by side on the left/right */
+      maybe_update_snap (snap_data, x1, y1, left_snap_pos, _y1 + _h / 2 - h / 2, SNAP_DIR_BOTH, SNAP_DIR_X, 0);
+      maybe_update_snap (snap_data, x1, y1, right_snap_pos, _y1 + _h / 2 - h / 2, SNAP_DIR_BOTH, SNAP_DIR_X, 0);
 
       /* If snapping is infinite, then add snapping points with minimal overlap
        * to prevent detachment.


### PR DESCRIPTION
## What

In the Display arrangement panel, dragging a monitor now also snaps to positions that align its center with an adjacent monitor's center -- both stacked (top/bottom) and side by side (left/right) -- alongside the existing edge snaps.

## Why

Currently only edges snap, so two monitors of different sizes cannot be centered relative to each other by dragging; you can only line up their top/bottom or left/right edges. A centered-but-abutting arrangement is a valid layout (muffin accepts it), so this is a UI-only gap.

## How

Four center-aligned candidates are added in `find_best_snapping()` (`panels/display/cc-display-arrangement.c`) as `SNAP_DIR_BOTH` peers of the existing edge candidates:

- stacked: the dragged monitor's center-x aligned to the other's, at its top or bottom edge;
- side by side: the dragged monitor's center-y aligned to the other's, at its left or right edge.

## Prior art

GNOME's gnome-control-center added the stacked (horizontal-edge) center-snap in commit `3070866d` ("display-arrangement: Add center-aligned snapping for horizontal edges", 2026-06-22). This brings that case to Cinnamon and additionally adds the side-by-side (vertical-edge) center case, which GNOME does not have.

## Testing

Built and drag-tested on Linux Mint 22 (Cinnamon, X11): a smaller monitor now snaps to vertically-centered when placed beside a larger one, and horizontally-centered when stacked, in addition to the edge snaps. No backend change required.
